### PR TITLE
Attempted to fix quick Item Wear

### DIFF
--- a/src/main/java/mcjty/incontrol/rules/SpawnRule.java
+++ b/src/main/java/mcjty/incontrol/rules/SpawnRule.java
@@ -280,7 +280,7 @@ public class SpawnRule {
         float r = rnd.nextFloat() * total;
         for (Pair<Float, ItemStack> pair : items) {
             if (r <= pair.getLeft()) {
-                return pair.getRight();
+                return pair.getRight().copy();
             }
             r -= pair.getLeft();
         }
@@ -297,7 +297,7 @@ public class SpawnRule {
             actions.add(event -> {
                 EntityLivingBase entityLiving = event.getEntityLiving();
                 if (entityLiving != null) {
-                    entityLiving.setItemStackToSlot(slot, item);
+                    entityLiving.setItemStackToSlot(slot, item.copy());
                 }
             });
         } else {
@@ -335,7 +335,7 @@ public class SpawnRule {
                             ((EntityEnderman) entityLiving).setHeldBlockState(b.getBlock().getStateFromMeta(b.getMetadata(item.getItemDamage())));
                         }
                     } else {
-                        entityLiving.setHeldItem(EnumHand.MAIN_HAND, item);
+                        entityLiving.setHeldItem(EnumHand.MAIN_HAND, item.copy());
                     }
                 }
             });
@@ -351,7 +351,7 @@ public class SpawnRule {
                             ((EntityEnderman) entityLiving).setHeldBlockState(b.getBlock().getStateFromMeta(b.getMetadata(item.getItemDamage())));
                         }
                     } else {
-                        entityLiving.setHeldItem(EnumHand.MAIN_HAND, item);
+                        entityLiving.setHeldItem(EnumHand.MAIN_HAND, item.copy());
                     }
                 }
             });


### PR DESCRIPTION
This PR adds .copy() to a few instances of ItemStacks given to mobs during their spawning process. addHeldItem, addArmorItem, and getRandomItem were patched this way.
 
This fixes the bug Morpheus1101 was reporting in Discord in regards to helmets disappearing.