### PR TITLE
Added a rule to check for spawns by mob spawners

### DIFF
--- a/src/main/java/mcjty/incontrol/rules/SpawnRule.java
+++ b/src/main/java/mcjty/incontrol/rules/SpawnRule.java
@@ -132,6 +132,7 @@ public class SpawnRule {
                 .attribute(Attribute.create(RANDOM))
                 .attribute(Attribute.create(CANSPAWNHERE))
                 .attribute(Attribute.create(NOTCOLLIDING))
+                .attribute(Attribute.create(SPAWNER))
                 .attribute(Attribute.create(INBUILDING))
                 .attribute(Attribute.create(INCITY))
                 .attribute(Attribute.create(INSTREET))

--- a/src/main/java/mcjty/incontrol/rules/support/GenericRuleEvaluator.java
+++ b/src/main/java/mcjty/incontrol/rules/support/GenericRuleEvaluator.java
@@ -24,6 +24,7 @@ import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.registry.EntityEntry;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
@@ -138,6 +139,9 @@ public class GenericRuleEvaluator {
         if (map.has(NOTCOLLIDING)) {
             addNotCollidingCheck(map);
         }
+        if (map.has(SPAWNER)) {
+            addSpawnerCheck(map);
+        }
 
         if (map.has(MOB)) {
             addMobsCheck(map);
@@ -246,6 +250,29 @@ public class GenericRuleEvaluator {
                     return !((EntityLiving) entity).isNotColliding();
                 } else {
                     return true;
+                }
+            });
+        }
+    }
+
+    private void addSpawnerCheck(AttributeMap map) {
+        boolean c = map.get(SPAWNER);
+        if (c) {
+            checks.add((event, query) -> {
+                if (event instanceof LivingSpawnEvent.CheckSpawn) {
+                    LivingSpawnEvent.CheckSpawn checkSpawn = (LivingSpawnEvent.CheckSpawn) event;
+                    return checkSpawn.isSpawner();
+                } else {
+                    return false;
+                }
+            });
+        } else {
+            checks.add((event, query) -> {
+                if (event instanceof LivingSpawnEvent.CheckSpawn) {
+                    LivingSpawnEvent.CheckSpawn checkSpawn = (LivingSpawnEvent.CheckSpawn) event;
+                    return !checkSpawn.isSpawner();
+                } else {
+                    return false;
                 }
             });
         }

--- a/src/main/java/mcjty/incontrol/rules/support/RuleKeys.java
+++ b/src/main/java/mcjty/incontrol/rules/support/RuleKeys.java
@@ -39,6 +39,7 @@ public interface RuleKeys {
     Key<Boolean> INBUILDING = Key.create(Type.BOOLEAN, "inbuilding");
     Key<Boolean> INSTREET = Key.create(Type.BOOLEAN, "instreet");
     Key<Boolean> INSPHERE = Key.create(Type.BOOLEAN, "insphere");
+    Key<Boolean> SPAWNER = Key.create(Type.BOOLEAN, "spawner");
 
     // Outputs
     Key<String> ACTION_RESULT = Key.create(Type.STRING, "result");


### PR DESCRIPTION
I added a rule to check if a mob is spawned with the isSpawner flag. This solves #29 and allows finer control with (vanilla) spawners. My personal use case for this is the following: only allow spawns in the overworld from mob spawners (they only generate in Roguelike Dungeons).

Example: Disable all spawns except for those from mob spawners.
`[
  {
    "spawner": false,
    "result": "deny"
  }
]`
