### PR TITLE
Subscribe to events with lowest priority to potentially catch more mods which have the same subscriber.

### DIFF
--- a/src/main/java/mcjty/incontrol/ForgeEventHandlers.java
+++ b/src/main/java/mcjty/incontrol/ForgeEventHandlers.java
@@ -25,7 +25,7 @@ public class ForgeEventHandlers {
 
     public static boolean debug = false;
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onEntityJoinWorld(EntityJoinWorldEvent event) {
         int i = 0;
         for (SpawnRule rule : RulesManager.rules) {
@@ -47,7 +47,7 @@ public class ForgeEventHandlers {
         }
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onEntitySpawnEvent(LivingSpawnEvent.CheckSpawn event) {
         int i = 0;
         for (SpawnRule rule : RulesManager.rules) {
@@ -69,7 +69,7 @@ public class ForgeEventHandlers {
         }
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onSummonAidEvent(ZombieEvent.SummonAidEvent event) {
         int i = 0;
         for (SummonAidRule rule : RulesManager.summonAidRules) {
@@ -92,7 +92,7 @@ public class ForgeEventHandlers {
 
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onPotentialSpawns(WorldEvent.PotentialSpawns event) {
         int i = 0;
         for (PotentialSpawnRule rule : RulesManager.potentialSpawnRules) {
@@ -119,7 +119,7 @@ public class ForgeEventHandlers {
         }
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onLivingExperienceDrop(LivingExperienceDropEvent event) {
         int i = 0;
         for (ExperienceRule rule : RulesManager.experienceRules) {
@@ -142,7 +142,7 @@ public class ForgeEventHandlers {
         }
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onLivingDrops(LivingDropsEvent event) {
         int i = 0;
         for (LootRule rule : RulesManager.lootRules) {


### PR DESCRIPTION
Should hopefully address https://github.com/McJtyMods/InControl/issues/109 and partially https://github.com/McJtyMods/InControl/issues/111 however if another mod happens to subscribe at lowest priority too then it becomes an mod load game, In our case we want InControl to always be last, so we can have the final say and actually be InControl of things, I branched this off because I am exploring further ideas, potentially creating a list of load afters (If the mod is problematic)