### PR TITLE
1.15 Fix performance issue when removing large amounts of mobs in potentialspawn

### DIFF
--- a/src/main/java/mcjty/incontrol/ForgeEventHandlers.java
+++ b/src/main/java/mcjty/incontrol/ForgeEventHandlers.java
@@ -137,11 +137,9 @@ public class ForgeEventHandlers {
             if (rule.match(event)) {
 
                 // First remove mob entries if needed
-                for (EntityType type : rule.getToRemoveMobs()) {
-                    for (int idx = event.getList().size() - 1; idx >= 0; idx--) {
-                        if (event.getList().get(idx).entityType == type) {
-                            event.getList().remove(idx);
-                        }
+                for (int idx = event.getList().size() - 1; idx >= 0; idx--) {
+                    if (rule.getToRemoveMobs().contains(event.getList().get(idx).entityType)) {
+                        event.getList().remove(idx);
                     }
                 }
 

--- a/src/main/java/mcjty/incontrol/rules/PotentialSpawnRule.java
+++ b/src/main/java/mcjty/incontrol/rules/PotentialSpawnRule.java
@@ -24,7 +24,9 @@ import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.logging.log4j.Level;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static mcjty.incontrol.rules.support.RuleKeys.*;
 
@@ -123,7 +125,7 @@ public class PotentialSpawnRule extends RuleBase<RuleBase.EventGetter> {
 
     private final GenericRuleEvaluator ruleEvaluator;
     private List<Biome.SpawnListEntry> spawnEntries = new ArrayList<>();
-    private List<EntityType> toRemoveMobs = new ArrayList<>();
+    private Set<EntityType> toRemoveMobs = new HashSet<>();
 
     private PotentialSpawnRule(AttributeMap map) {
         super(InControl.setup.getLogger());
@@ -208,7 +210,7 @@ public class PotentialSpawnRule extends RuleBase<RuleBase.EventGetter> {
         return ruleEvaluator.match(event, EVENT_QUERY);
     }
 
-    public List<EntityType> getToRemoveMobs() {
+    public Set<EntityType> getToRemoveMobs() {
         return toRemoveMobs;
     }
 }


### PR DESCRIPTION
The potentialspawn event now only loops through all entity types once instead of once for every mob it has to remove. 
This should have significant benefits when large amounts of mobs are removed in potential spawn. 

This should avoid problems like this one: 
![image](https://user-images.githubusercontent.com/4283717/77061424-7da56600-69da-11ea-9b6e-f6d95f9cde03.png)
https://sparkprofiler.github.io/#8NaP16FyU2