### PR TITLE
Fix default minheight not being -64, adjusting it to the correct min build height for vanilla minecraft for correct mob spawning in deep caves.

### DIFF
--- a/src/main/java/mcjty/incontrol/spawner/SpawnerConditions.java
+++ b/src/main/java/mcjty/incontrol/spawner/SpawnerConditions.java
@@ -367,7 +367,7 @@ public class SpawnerConditions {
         private int verticalMaxdist = -1;
         private int mindaycount = 0;
         private int maxdaycount = Integer.MAX_VALUE;
-        private int minheight = 1;
+        private int minheight = -64;
         private int maxheight = 256;
         private boolean inLiquid = false;
         private boolean inWater = false;

--- a/src/main/java/mcjty/incontrol/spawner/SpawnerConditions.java
+++ b/src/main/java/mcjty/incontrol/spawner/SpawnerConditions.java
@@ -368,7 +368,7 @@ public class SpawnerConditions {
         private int mindaycount = 0;
         private int maxdaycount = Integer.MAX_VALUE;
         private int minheight = -64;
-        private int maxheight = 256;
+        private int maxheight = 320;
         private boolean inLiquid = false;
         private boolean inWater = false;
         private boolean inLava = false;


### PR DESCRIPTION
Vanilla minecraft caves go as far as -64 now, incontrol is still defaulting the minheight to 1, this PR fixes that so things can spawn deep in the caves correctly. 

Before this fix it was required to manually specify your own minheight of -64 in the json to work around it.